### PR TITLE
add MissingAttributeError to restme errors when it occurs

### DIFF
--- a/lib/restme/scope/field/rules.rb
+++ b/lib/restme/scope/field/rules.rb
@@ -19,6 +19,10 @@ module Restme
           scoped = select_nested_scope(scoped) if valid_nested_fields_select
 
           insert_attachments(scoped)
+        rescue ActiveModel::MissingAttributeError => e
+          restme_scope_errors({ body: model_fields_select, message: e.message })
+
+          restme_scope_status(:bad_request)
         end
 
         def select_nested_scope(scoped)

--- a/lib/restme/scope/rules.rb
+++ b/lib/restme/scope/rules.rb
@@ -33,12 +33,16 @@ module Restme
       ].freeze
 
       def pagination_response
-        @pagination_response ||= restme_pagination_response
+        @pagination_response ||= begin
+          prepare_model_scope
+
+          restme_scope_errors.presence || restme_pagination_response
+        end
       end
 
       def model_scope_object
         @model_scope_object ||= begin
-          model_scope unless any_scope_errors.present?
+          prepare_model_scope
 
           restme_scope_errors.presence || model_scope.first
         end
@@ -47,12 +51,14 @@ module Restme
       private
 
       def restme_pagination_response
-        any_scope_errors
-
-        restme_scope_errors.presence || {
+        {
           objects: model_scope,
           pagination: pagination
         }
+      end
+
+      def prepare_model_scope
+        model_scope if any_scope_errors.blank?
       end
 
       def any_scope_errors

--- a/spec/lib/restme_controller_spec.rb
+++ b/spec/lib/restme_controller_spec.rb
@@ -600,6 +600,28 @@ RSpec.describe "RestmeController", type: :controller do
               expect { establishments_controller.index }.to execute_queries(expected_queries)
             end
           end
+
+          context "when select nested_field without select foreign key" do
+            let(:query_parameters) do
+              {
+                fields_select: "id",
+                nested_fields_select: "establishment",
+                id_sort: :asc
+              }
+            end
+
+            let(:expected_result) do
+              [{ body: "products.id", message: "missing attribute 'establishment_id' for Product" }]
+            end
+
+            it "returns products" do
+              expect(products_controller.index[:body]).to eq(expected_result.as_json)
+            end
+
+            it "returns ok status" do
+              expect(products_controller.index[:status]).to eq(:bad_request)
+            end
+          end
         end
       end
 
@@ -1670,6 +1692,33 @@ RSpec.describe "RestmeController", type: :controller do
 
               it "returns ok status" do
                 expect(establishments_controller.show[:status]).to eq(:ok)
+              end
+            end
+
+            context "when select nested_field without select foreign key" do
+              let(:controller_params) do
+                {
+                  id: product_a.id
+                }
+              end
+
+              let(:query_parameters) do
+                {
+                  fields_select: "id",
+                  nested_fields_select: "establishment"
+                }
+              end
+
+              let(:expected_result) do
+                [{ body: "products.id", message: "missing attribute 'establishment_id' for Product" }]
+              end
+
+              it "returns products" do
+                expect(products_controller.show[:body]).to eq(expected_result.as_json)
+              end
+
+              it "returns ok status" do
+                expect(products_controller.show[:status]).to eq(:bad_request)
               end
             end
           end


### PR DESCRIPTION
## Index actions

### When select foreign key
<img width="1589" height="729" alt="image" src="https://github.com/user-attachments/assets/ac61ef09-ebc3-4c8e-9dfb-11bf210effea" />

### When does not select foreign key
<img width="1589" height="729" alt="image" src="https://github.com/user-attachments/assets/baae475f-e53d-4129-b10e-ded646a2ae83" />


## Show actions
### When select foreign key
<img width="1589" height="729" alt="image" src="https://github.com/user-attachments/assets/bb778960-f6e8-4ded-9de0-f658d39b9084" />

### When does not select foreign key
<img width="1589" height="729" alt="image" src="https://github.com/user-attachments/assets/3669ba08-ab31-48b1-9a12-f31f343f4d20" />




